### PR TITLE
Promote to prod environment

### DIFF
--- a/components/python-hhdwxnzu/overlays/prod/deployment-patch.yaml
+++ b/components/python-hhdwxnzu/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-appstudio/dance-bootstrap-app:latest
+      - image: artifactory-docker-artifactory-jcr.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/python-hhdwxnzu:56fda689badbe9bdceaa91d0d002b836eca688b7@sha256:92f4f3d430145713685f682e6dceaea4487461daedff58b44708b97b808d425a
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/python-hhdwxnzu:56fda689badbe9bdceaa91d0d002b836eca688b7@sha256:92f4f3d430145713685f682e6dceaea4487461daedff58b44708b97b808d425a